### PR TITLE
Interrelated fixes for Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ cd pyxpcconnection
 sudo python setup.py install
 ```
 
+If you are compiling and running using Python3 installed via HomeBrew run:
+
+```bash
+brew install boost-python --with-python3
+ln -s /usr/local/lib/libboost_python3.a /usr/local/lib/libboost_python-py34.a
+``` 
+
 If you want to work on the development of pyxpcconnection, use this instead:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ modules = [
         'xpcconnection',
         ['src/XpcConnectionBase.cpp',
          'src/bindings.cpp'],
-        extra_compile_args=['-std=c++11'],
+        extra_compile_args=['-std=c++11', '-stdlib=libc++', '-mmacosx-version-min=10.9'],
         libraries = boost_libs
     )
 ]

--- a/src/XpcConnectionBase.cpp
+++ b/src/XpcConnectionBase.cpp
@@ -167,7 +167,7 @@ boost::python::object XpcConnectionBase::XpcObjectToValue(xpc_object_t xpcObject
 #if PY_MAJOR_VERSION >= 3
         obj = boost::python::object( boost::python::handle<>( PyBytes_FromStringAndSize(value.c_str(), value.size() ) ) );
 #else
-        obj = boost::python::object(new_buffer);
+        obj = boost::python::object(value);
 #endif
     }
     else if (valueType == XPC_TYPE_DATA) {
@@ -175,7 +175,7 @@ boost::python::object XpcConnectionBase::XpcObjectToValue(xpc_object_t xpcObject
 #if PY_MAJOR_VERSION >= 3
         obj = boost::python::object( boost::python::handle<>( PyBytes_FromStringAndSize(value.c_str(), value.size() ) ) );
 #else
-        obj = boost::python::object(new_buffer);
+        obj = boost::python::object(value);
 #endif
     }
     else if (valueType == XPC_TYPE_DICTIONARY) {

--- a/src/XpcConnectionBase.cpp
+++ b/src/XpcConnectionBase.cpp
@@ -164,11 +164,19 @@ boost::python::object XpcConnectionBase::XpcObjectToValue(xpc_object_t xpcObject
     }
     else if (valueType == XPC_TYPE_STRING) {
         std::string value(xpc_string_get_string_ptr(xpcObject));
-        obj = boost::python::object(value);
+#if PY_MAJOR_VERSION >= 3
+        obj = boost::python::object( boost::python::handle<>( PyBytes_FromStringAndSize(value.c_str(), value.size() ) ) );
+#else
+        obj = boost::python::object(new_buffer);
+#endif
     }
     else if (valueType == XPC_TYPE_DATA) {
         std::string value((char *)xpc_data_get_bytes_ptr(xpcObject), xpc_data_get_length(xpcObject));
-        obj = boost::python::object(value);
+#if PY_MAJOR_VERSION >= 3
+        obj = boost::python::object( boost::python::handle<>( PyBytes_FromStringAndSize(value.c_str(), value.size() ) ) );
+#else
+        obj = boost::python::object(new_buffer);
+#endif
     }
     else if (valueType == XPC_TYPE_DICTIONARY) {
         obj = XpcConnectionBase::XpcDictToDict(xpcObject);
@@ -180,7 +188,11 @@ boost::python::object XpcConnectionBase::XpcObjectToValue(xpc_object_t xpcObject
         std::string buffer((char *)xpc_uuid_get_bytes(xpcObject), sizeof(uuid_t));
         std::string new_buffer;
         new_buffer.assign(buffer);
+#if PY_MAJOR_VERSION >= 3
+        obj = boost::python::object( boost::python::handle<>( PyBytes_FromStringAndSize(new_buffer.c_str(), new_buffer.size() ) ) );
+#else
         obj = boost::python::object(new_buffer);
+#endif
     }
 
     PyGILState_Release(gstate);


### PR DESCRIPTION
Setup.py clang fixes. 
Readme HomeBrew updates. 
Python3 Unicode handling

Tested on macOS 10.12, xcode 9.1 with:

- macOS bundled Python 2.7
- Python.org Python 3.5
- HomeBrew Python 3.6.3